### PR TITLE
Decompile LoaderSysLoadIopModule

### DIFF
--- a/src/os/loaderSys.c
+++ b/src/os/loaderSys.c
@@ -9,6 +9,8 @@ extern char D_00136318[];  // "ld:\t\tdecode section\n"
 extern char D_00136330[];  // "ld:\t%15s(progbit): 0x%08x(0x%08x) %s\n"
 extern char D_00136358[];  // "ld:\t%15s(overlaydata): 0x%08x(0x%08x) %s\n"
 extern char D_00136388[];  // "ld:\t%15s(nobit)  : 0x%08x(0x%08x) %s\n"
+extern char D_00136C00[];
+extern char D_00136C10[];
 
 extern u32 D_00139F04; // heap pointer
 
@@ -28,6 +30,9 @@ extern s32 D_0013C910[IOP_MEM_LIST_LEN];
 extern struct unk D_0013C110[MAX_INTC_HANDLERS];
 
 extern char D_0013A100[]; // "host0:"
+extern const char D_0013A118[];
+extern const char D_0013A120[];
+extern const char D_0013A128[];
 
 extern const char D_0013D110[]; // Filled at runtime: "cdrom0:\SCPS_15"
 extern const char D_0013A0F8[]; // "%s"
@@ -544,7 +549,23 @@ const char *LoaderSysGetBootArg(void)
     return D_0013D110;
 }
 
-INCLUDE_ASM(const s32, "os/loaderSys", LoaderSysLoadIopModule);
+int LoaderSysLoadIopModule(const char* path, int arg_count, void* args)
+{
+    int result;
+    PutString(0x4080FF00, D_00136C00);
+    PutString(0x80C0FF00, D_0013A118, path);
+    PutStringS(0x4080FF00, D_0013A120);
+
+    result = sceSifLoadModule(path, arg_count, args);
+
+    if (result < 0) {
+        PutStringS(0xFF804000, D_00136C10, path, result);
+        return -1;
+    }
+
+    PutStringS(0x4080FF00, D_0013A128);
+    return 0;
+}
 
 INCLUDE_ASM(const s32, "os/loaderSys", LoaderSysUnloadIopModuleByName);
 


### PR DESCRIPTION
https://decomp.me/scratch/l3dHH

Not sure how data extraction works yet. The extern strings are all in the `loaderSys.rodata.s` section if you want me to pull them out as well!