### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Disclaimer: Linux or WSL2 required
 1. ``sudo apt install gcc-mipsel-linux-gnu binutils-mips-linux-gnu ninja-build``
 2. ``sudo apt install python3-pip``
 3. ``python3 -m pip install -U -r requirements.txt``
-4. Create an ``iso`` directory in the root directory
-5. From a Shadow of the Colossus Preview Version ISO, extract ``SCPS_150.97`` into the ``iso`` directory
-6. ``configure.py``
-7. ``ninja``
+4. Get the required compiler version by running ``scripts/setup_compiler.sh``
+5. Create an ``iso`` directory in the root directory
+6. From a Shadow of the Colossus Preview Version ISO, extract ``SCPS_150.97`` into the ``iso`` directory
+7. ``configure.py``
+8. ``ninja``

--- a/README.md
+++ b/README.md
@@ -8,20 +8,22 @@
 <!-- Shields -->
 ![code-progress-badge] [![Contributors][contributors-badge]][contributors-url]
 
-We are currently targeting the main ELF (``SCPS_150.97``) of the Preview version.
+We are currently targeting the Preview Version's main ELF (``SCPS_150.97``, sha1: ``c4d5576d1cae3721c411a746c7845f5c6f026dbb``).
 
 <a href="https://discord.gg/3nmDn6p7" target="_blank">
   <img src="https://discord.com/api/guilds/465610776762384394/widget.png?style=banner2" alt="Discord Banner">
 </a>
 
-
-## Setup
-Disclaimer: Linux or WSL2 required
+## Getting Started
+### Requirements
+**Disclaimer**: Linux or WSL2 required
 1. ``sudo apt install gcc-mipsel-linux-gnu binutils-mips-linux-gnu ninja-build``
 2. ``sudo apt install python3-pip``
 3. ``python3 -m pip install -U -r requirements.txt``
-4. Get the required compiler version by running ``scripts/setup_compiler.sh``
-5. Create an ``iso`` directory in the root directory
-6. From a Shadow of the Colossus Preview Version ISO, extract ``SCPS_150.97`` into the ``iso`` directory
-7. ``configure.py``
-8. ``ninja``
+4. ``scripts/setup_compiler.sh``
+
+### Setup
+1. Create an ``iso`` directory in the root directory
+2. From a Shadow of the Colossus Preview Version ISO, extract ``SCPS_150.97`` into the ``iso`` directory
+3. ``configure.py`` (optionally pass ``-c`` to do a clean split)
+4. ``ninja``

--- a/configure.py
+++ b/configure.py
@@ -7,8 +7,8 @@ import subprocess
 import sys
 import re
 
-from   pathlib import Path
-from   typing  import Dict, List, Set, Union
+from pathlib import Path
+from typing import Dict, List, Set, Union
 
 from fix_gp import main as fix_gp_main
 
@@ -16,7 +16,7 @@ import ninja_syntax
 
 import splat
 import splat.scripts.split as split
-from   splat.segtypes.linker_entry import LinkerEntry
+from splat.segtypes.linker_entry import LinkerEntry
 
 ROOT = Path(__file__).parent
 TOOLS_DIR = ROOT / "tools"
@@ -28,23 +28,16 @@ ELF_PATH = f"build/{BASENAME}"
 MAP_PATH = f"build/{BASENAME}.map"
 PRE_ELF_PATH = f"build/{BASENAME}.elf"
 
-COMMON_INCLUDES = "-Iinclude -I include/sdk/ee -I include/sdk -I include/gcc -I include/gcc/gcc-lib"
+COMMON_INCLUDES = "-Iinclude -I include/sdk/ee -I include/sdk -I include/gcc"
 
 COMPILER = "ee-gcc2.96"
 GAME_CC_DIR = f"{TOOLS_DIR}/cc/{COMPILER}/bin"
-LIB_CC_DIR = f"{TOOLS_DIR}/cc/{COMPILER}/bin"
 
 GAME_COMPILE_CMD = f"{GAME_CC_DIR}/ee-gcc -c {COMMON_INCLUDES} -O2 -g2"
 
-LIB_COMPILE_CMD = f"{LIB_CC_DIR}/ee-gcc -c -I include/gcc-9.26 {COMMON_INCLUDES} -O2 -G8 -g -x c++"
 
-WIBO_VER = "0.6.4"
-
-
-def exec_shell(command: List[str], stdout = subprocess.PIPE) -> str:
-    ret = subprocess.run(
-        command, stdout=stdout, stderr=subprocess.PIPE, text=True
-    )
+def exec_shell(command: List[str], stdout=subprocess.PIPE) -> str:
+    ret = subprocess.run(command, stdout=stdout, stderr=subprocess.PIPE, text=True)
     return ret.stdout
 
 
@@ -57,16 +50,17 @@ def clean():
 
 
 def write_permuter_settings():
+    rel_cc_dir = Path(GAME_CC_DIR).relative_to(ROOT)
     with open("permuter_settings.toml", "w") as f:
         f.write(
-            f"""compiler_command = "{os.path.relpath(GAME_COMPILE_CMD, ROOT)} -D__GNUC__"
+            f"""compiler_command = "{rel_cc_dir}ee-gcc -c {COMMON_INCLUDES} -O2 -g2"
 assembler_command = "mips-linux-gnu-as -march=r5900 -mabi=eabi -Iinclude"
 compiler_type = "gcc"
 
 [preserve_macros]
 
 [decompme.compilers]
-"tools/build/cc/gcc/gcc" = "{COMPILER}"
+"{rel_cc_dir}/ee-gcc" = "{COMPILER}"
 """
         )
 
@@ -101,24 +95,18 @@ def build_stuff(linker_entries: List[LinkerEntry]):
 
     # Rules
     cross = "mips-linux-gnu-"
-    ld_args = f"-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -T config/undefined_syms.txt -Map $mapfile -T $in -o $out"
+    ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -T config/undefined_syms.txt -Map $mapfile -T $in -o $out"
 
     ninja.rule(
         "as",
         description="as $in",
-        command=f"cpp {COMMON_INCLUDES} $in | iconv -f=UTF-8 -t=EUC-JP $in | {cross}as -no-pad-sections -EL -march=5900 -mabi=eabi -Iinclude -o $out",
+        command=f"cpp {COMMON_INCLUDES} $in | {cross}as -no-pad-sections -EL -march=5900 -mabi=eabi -Iinclude -o $out",
     )
 
     ninja.rule(
         "cc",
         description="cc $in",
         command=f"{GAME_COMPILE_CMD} $in -o $out && {cross}strip $out -N dummy-symbol-name",
-    )
-
-    ninja.rule(
-        "libcc",
-        description="cc $in",
-        command=f"{LIB_COMPILE_CMD} $in -o $out && {cross}strip $out -N dummy-symbol-name",
     )
 
     ninja.rule(
@@ -156,7 +144,9 @@ def build_stuff(linker_entries: List[LinkerEntry]):
             build(entry.object_path, entry.src_paths, "cpp")
         elif isinstance(seg, splat.segtypes.common.c.CommonSegC):
             build(entry.object_path, entry.src_paths, "cc")
-        elif isinstance(seg, splat.segtypes.common.databin.CommonSegDatabin) or isinstance(seg, splat.segtypes.common.rodatabin.CommonSegRodatabin):
+        elif isinstance(
+            seg, splat.segtypes.common.databin.CommonSegDatabin
+        ) or isinstance(seg, splat.segtypes.common.rodatabin.CommonSegRodatabin):
             build(entry.object_path, entry.src_paths, "as")
         else:
             print(f"ERROR: Unsupported build segment type {seg.type}")
@@ -184,39 +174,44 @@ def build_stuff(linker_entries: List[LinkerEntry]):
     )
 
 
-opcode_pattern = re.compile(
-    r"\/\* ([0-9A-Z]+) ([0-9A-Z]+) ([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2}) \*\/  (\b(bne|bnel|beq|beql|bnez|bnezl|beqzl|bgez|bgezl|bgtz|bgtzl|blez|blezl|bltz|bltzl|b)\b.*)"
-)  # Pattern to workaround unintended nops around loops
-nop_bugged_funcs = set(
+# Pattern to workaround unintended nops around loops
+COMMENT_PART = r"\/\* (.+) ([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2}) \*\/"
+INSTRUCTION_PART = r"(\b(bne|bnel|beq|beql|bnez|bnezl|beqzl|bgez|bgezl|bgtz|bgtzl|blez|blezl|bltz|bltzl|b)\b.*)"
+OPCODE_PATTERN = re.compile(f"{COMMENT_PART}  {INSTRUCTION_PART}")
+
+PROBLEMATIC_FUNCS = set(
     [
-        "OutputLinkerScriptFile.s",
-        "LoaderSysResetSystem.s",
-        "func_00105A60.s",
-        "_putString.s",
-        "InitDisp.s"
+        "OutputLinkerScriptFile",
+        "LoaderSysResetSystem",
+        "func_00105A60",
+        "_putString",
+        "InitDisp",
     ]
 )
 
 
-def replace_instructions_with_opcodes() -> None:
-    for root, dirs, files in os.walk("asm/nonmatchings/"):
-        for filename in files:
-            if filename not in nop_bugged_funcs:
-                continue
+def replace_instructions_with_opcodes(asm_folder: Path) -> None:
+    nm_folder = ROOT / asm_folder / "nonmatchings"
 
-            filepath = os.path.join(root, filename)
+    for p in nm_folder.rglob("*.s"):
+        if p.stem not in PROBLEMATIC_FUNCS:
+            continue
 
-            with open(filepath, "r") as file:
-                content = file.read()
+        with p.open("r") as file:
+            content = file.read()
 
-            if re.search(opcode_pattern, content):
-                # Reference found, replace
-                # Embed the opcode, we have to swap byte order for correct endianness
-                content = re.sub(opcode_pattern, r"/* \1 \2 \3\4\5\6 */  .word      0x\6\5\4\3 /* \7 */", content)
+        if re.search(OPCODE_PATTERN, content):
+            # Reference found
+            # Embed the opcode, we have to swap byte order for correct endianness
+            content = re.sub(
+                OPCODE_PATTERN,
+                r"/* \1 \2\3\4\5 */  .word      0x\5\4\3\2 /* \6 */",
+                content,
+            )
 
-                # Write the updated content back to the file
-                with open(filepath, "w") as file:
-                    file.write(content)
+            # Write the updated content back to the file
+            with p.open("w") as file:
+                file.write(content)
 
 
 if __name__ == "__main__":
@@ -234,25 +229,18 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "-noconvert",
-        "--no-eucjp-converting",
-        help="Do not convert to EUC-JP the disassembly strings",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-noop",
-        "--no-opcode-hack",
-        help="Do not replace asm instructions with raw opcodes for functions that trigger the short loop bug",
+        "-noloop",
+        "--no-short-loop-workaround",
+        help="Do not replace branch instructions with raw opcodes for functions that trigger the short loop bug",
         action="store_true",
     )
     args = parser.parse_args()
 
     if args.clean:
         clean()
-    
+
     if args.cleansrc:
         shutil.rmtree("src", ignore_errors=True)
-
 
     split.main([YAML_FILE], modes="all", verbose=False)
 
@@ -265,8 +253,8 @@ if __name__ == "__main__":
     if not split.config["options"]["use_gp_rel_macro_nonmatching"]:
         fix_gp_main()
 
-    if not args.no_opcode_hack:
-        replace_instructions_with_opcodes()
+    if not args.no_short_loop_workaround:
+        replace_instructions_with_opcodes(split.config["options"]["asm_path"])
 
     if not os.path.isfile("compile_commands.json"):
         exec_shell(["ninja", "-t", "compdb"], open("compile_commands.json", "w"))

--- a/fix_gp.py
+++ b/fix_gp.py
@@ -4,6 +4,7 @@ import tqdm
 
 
 def main():
+    inst_pattern = r"(\/\* .* \*\/  .*\([^) ]+\) \/\* gp_rel: .*\*\/)"
     asm_files = glob.glob("asm/**/*.s", recursive=True)
     for asm_file in tqdm.tqdm(asm_files, desc="Fixing gp_rel"):
         lines: list[str] = []
@@ -11,16 +12,17 @@ def main():
         with open(asm_file, mode="r") as fh:
             lines.append(fh.read())
 
-        syms.update(re.findall(r"\/\* gp_rel: \(([^)]+)\).*", lines[0]))
-        
+        syms.update(re.findall(r"\(([^) ]+).*\) \/\* gp_rel: .*\*\/", lines[0]))
+        lines[0] = re.sub(inst_pattern, ".set at\n\\1\n.set noat", lines[0])
+
         if syms:
             lines.insert(0, "/* Symbols accessed via $gp register */\n")
             lines.insert(1, "\n")
             for s in syms:
                 lines.insert(1, f".extern {s}, 1\n")
 
-        with open(asm_file, mode="w") as wh:
-            wh.writelines(lines)
+            with open(asm_file, mode="w") as wh:
+                wh.writelines(lines)
 
 
 if __name__ == "__main__":

--- a/scripts/setup_compiler.sh
+++ b/scripts/setup_compiler.sh
@@ -16,7 +16,7 @@ curl -L -o "$TAR_FILE" "$FILE_URL"
 tar -xf "$TAR_FILE" -C "$TARGET_DIR"
 
 # Set executable permissions for binaries in the cc directory
-chmod +x -R $TARGET_DIR
+chmod +x -R "$TARGET_DIR"
 
 # Clean up by removing the downloaded file
 rm "$TAR_FILE"

--- a/scripts/setup_compiler.sh
+++ b/scripts/setup_compiler.sh
@@ -16,7 +16,7 @@ curl -L -o "$TAR_FILE" "$FILE_URL"
 tar -xf "$TAR_FILE" -C "$TARGET_DIR"
 
 # Set executable permissions for binaries in the cc directory
-find "$TARGET_DIR" -type f -exec chmod +x {} \;
+chmod +x -R $TARGET_DIR
 
 # Clean up by removing the downloaded file
 rm "$TAR_FILE"


### PR DESCRIPTION
Updated the readme so it mentions the compiler stetup script, also simplified the chmod command.

`fix_gp.py` was adjusted to add a workaround for a binutils bug which would prevent people from making scratches with non-matchings asm

The configure.py changes are mostly removing unneeded stuff and tidying up, changes:
- Removed an unused include dir (`include/gcc/gcc-lib`)
- Removed the lib compiler stuff
- Removed the `WIBO_VER` string as this project doesn't use Wibo
- Fixed the permuter_settings string
- Remove (temporarily as mentioned in the Discord) the iconv step
- Tidied up the function that deals with the short loop bug