### PR TITLE
Named registers

### DIFF
--- a/config/sotc_preview.yaml
+++ b/config/sotc_preview.yaml
@@ -31,7 +31,7 @@ options:
     string_encoding: EUC-JP
     rodata_string_guesser_level: 2 # improve string detection
     disasm_unknown: True
-    named_regs_for_c_funcs: False
+    named_regs_for_c_funcs: True
     gp_value: 0x141e70
     find_file_boundaries: False
     section_order: [".text", ".data", ".rodata", ".lit4", ".sdata", ".sbss", ".bss"]

--- a/include/asm_regs.h
+++ b/include/asm_regs.h
@@ -1,0 +1,35 @@
+#ifndef ASM_REGNAMES_H
+#define ASM_REGNAMES_H
+
+__asm__(
+    "#define zero 0\n"
+    "#define v0 2\n"
+    "#define v1 3\n"
+    "#define a0 4\n"
+    "#define a1 5\n"
+    "#define a2 6\n"
+    "#define a3 7\n"
+    "#define t0 8\n"
+    "#define t1 9\n"
+    "#define t2 10\n"
+    "#define t3 11\n"
+    "#define t4 12\n"
+    "#define t5 13\n"
+    "#define t6 14\n"
+    "#define t7 15\n"
+    "#define s0 16\n"
+    "#define s1 17\n"
+    "#define s2 18\n"
+    "#define s3 19\n"
+    "#define s4 20\n"
+    "#define s5 21\n"
+    "#define s6 22\n"
+    "#define s7 23\n"
+    "#define t8 24\n"
+    "#define t9 25\n"
+    "#define k0 26\n"
+    "#define k1 27\n"
+    "#define s8 30\n"
+    "#define ra 31");
+
+#endif /* ASM_REGNAMES_H */

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -3,24 +3,43 @@
 
 #if !defined(SPLAT) && !defined(M2CTX) && !defined(PERMUTER)
 #ifndef INCLUDE_ASM
-#define INCLUDE_ASM(FOLDER, NAME)                     \
+#define INCLUDE_ASM_TOP(FOLDER, NAME)                 \
     __asm__(                                          \
         ".section .text\n"                            \
         "    .set noat\n"                             \
         "    .set noreorder\n"                        \
         "    .globl " #NAME ".NON_MATCHING\n"         \
         "    .type " #NAME ".NON_MATCHING, @object\n" \
-        "    " #NAME ".NON_MATCHING:\n"               \
-        "    .include \"" FOLDER "/" #NAME ".s\"\n"   \
+        "    " #NAME ".NON_MATCHING:\n"
+
+#ifndef PREPROCESS_ASM
+#define INCLUDE_ASM_MIDDLE(FOLDER, NAME) \
+        "    .include \"" FOLDER "/" #NAME ".s\"\n"
+#else
+#define INCLUDE_ASM_MIDDLE(FOLDER, NAME) \
+        "    #include \"" FOLDER "/" #NAME ".s\"\n"
+#endif
+
+#define INCLUDE_ASM_BOTTOM() \
         "    .set reorder\n"                          \
         "    .set at\n")
+
+#define INCLUDE_ASM(FOLDER, NAME)        \
+        INCLUDE_ASM_TOP(FOLDER, NAME)    \
+        INCLUDE_ASM_MIDDLE(FOLDER, NAME) \
+        INCLUDE_ASM_BOTTOM()
+
+#ifdef PREPROCESS_ASM
+#include "asm_regs.h"
+#endif
+
 #endif
 #ifndef INCLUDE_RODATA
-#define INCLUDE_RODATA(FOLDER, NAME)                \
-    __asm__(                                        \
-        ".section .rodata\n"                        \
-        "    .include \"" FOLDER "/" #NAME ".s\"\n" \
-        ".section .text")
+#define INCLUDE_RODATA(FOLDER, NAME)                    \
+        __asm__(                                        \
+            ".section .rodata\n"                        \
+            "    .include \"" FOLDER "/" #NAME ".s\"\n" \
+            ".section .text")
 #endif
 __asm__(".include \"include/labels.inc\"\n");
 #else


### PR DESCRIPTION
Add a pre-processing step before assembling so `INCLUDE_ASM` files can have named registers too, this can be easily disabled if desired by just changing `named_regs_for_c_funcs` in the .yaml back to `False`